### PR TITLE
Fix Fluent UI class composition warnings

### DIFF
--- a/portal/src/components/diff/CodeDiffViewer.tsx
+++ b/portal/src/components/diff/CodeDiffViewer.tsx
@@ -1,4 +1,4 @@
-import { Button, makeStyles, shorthands, tokens } from '@fluentui/react-components'
+import { Button, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components'
 import { DocumentText24Regular } from '@fluentui/react-icons'
 
 export type DiffFile = {
@@ -97,9 +97,7 @@ export const CodeDiffViewer = ({ files, selectedFile, onFileSelect }: CodeDiffVi
         {files.map((file, index) => {
           const isActive = index === activeIndex
           const tabId = `diff-viewer-tab-${index}`
-          const className = [styles.fileButton, isActive ? styles.activeFile : undefined]
-            .filter(Boolean)
-            .join(' ')
+          const className = mergeClasses(styles.fileButton, isActive && styles.activeFile)
 
           return (
             <Button

--- a/portal/src/components/input/MainInputComponent.tsx
+++ b/portal/src/components/input/MainInputComponent.tsx
@@ -1,4 +1,12 @@
-import { Button, Textarea, Tooltip, makeStyles, shorthands, tokens } from '@fluentui/react-components'
+import {
+  Button,
+  Textarea,
+  Tooltip,
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  tokens,
+} from '@fluentui/react-components'
 import { Attach24Regular, Mic24Regular } from '@fluentui/react-icons'
 import { keyframes } from '@griffel/react'
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
@@ -214,13 +222,11 @@ export const MainInputComponent = ({
     return ''
   }, [hasVoiceInput, voice.isRecording, voice.isSupported, voiceNotice, voiceAttempted])
 
-  const voiceButtonClassName = [
+  const voiceButtonClassName = mergeClasses(
     styles.iconButton,
-    voice.isRecording ? styles.voiceButtonActive : undefined,
-    prefersReducedMotion ? styles.voiceButtonReducedMotion : undefined,
-  ]
-    .filter(Boolean)
-    .join(' ')
+    voice.isRecording && styles.voiceButtonActive,
+    prefersReducedMotion && styles.voiceButtonReducedMotion,
+  )
 
   const voiceButtonLabel = voice.isRecording ? 'Stop voice input' : 'Start voice input'
 

--- a/portal/src/components/layout/LeftRail.tsx
+++ b/portal/src/components/layout/LeftRail.tsx
@@ -1,4 +1,4 @@
-import { Badge, Text, Tooltip, makeStyles, shorthands, tokens } from '@fluentui/react-components'
+import { Badge, Text, Tooltip, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components'
 import {
   BookInformation24Regular,
   ClipboardTaskListLtr24Regular,
@@ -223,9 +223,7 @@ export const LeftRail = () => {
               key={item.key}
               to={item.to}
               end={item.end}
-              className={({ isActive }) =>
-                [styles.link, isActive ? styles.linkActive : undefined].filter(Boolean).join(' ')
-              }
+              className={({ isActive }) => mergeClasses(styles.link, isActive && styles.linkActive)}
             >
               {content}
             </NavLink>

--- a/portal/src/components/layout/TopBar.tsx
+++ b/portal/src/components/layout/TopBar.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   DialogTrigger,
   makeStyles,
+  mergeClasses,
   shorthands,
   tokens,
 } from '@fluentui/react-components'
@@ -233,9 +234,7 @@ export const TopBar = ({ children }: { children?: ReactNode }) => {
               key={item.key}
               to={item.to}
               end={item.end}
-              className={({ isActive }) =>
-                [styles.navLink, isActive ? styles.navLinkActive : undefined].filter(Boolean).join(' ')
-              }
+              className={({ isActive }) => mergeClasses(styles.navLink, isActive && styles.navLinkActive)}
             >
               {item.label}
             </NavLink>


### PR DESCRIPTION
## Summary
- use Fluent UI's `mergeClasses` helper when composing class names in the main input, diff viewer, top bar, and left rail components

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1461c08588326980cb92b92ecf32e